### PR TITLE
fix(CHANGELOG.md): add meta file for Unity to consume

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d417de15ff72f864c8ab1251c2eae118
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Unity would complain if the package was included in another project
due to packages being read only and therefore not being able to
generate the .meta file for the CHANGELOG.md file.

This fix simply adds a meta file in manually.