### PR TITLE
fix(Interactions): interactor to emit collision stopped on disable - fixes #9

### DIFF
--- a/Interactions/Interactors/SharedResources/NestedPrefabs/Interaction.Touching.prefab
+++ b/Interactions/Interactors/SharedResources/NestedPrefabs/Interaction.Touching.prefab
@@ -44,6 +44,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9a5cea3d73a4234aa48131d662d170b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  autoRejectStates: 0
   componentTypes: {fileID: 1474031633576177774}
 --- !u!114 &1474031633576177774
 MonoBehaviour:
@@ -150,6 +151,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53fca345d7764be0a2f6ce49a7d64b3e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  autoRejectStates: 0
   rule:
     field: {fileID: 677417551805029599}
 --- !u!114 &677417551805029599
@@ -164,6 +166,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9a5cea3d73a4234aa48131d662d170b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  autoRejectStates: 0
   componentTypes: {fileID: 1617230785627786039}
 --- !u!114 &1617230785627786039
 MonoBehaviour:


### PR DESCRIPTION
There was an issue where an Interactor would not emit the
CollisionStopped event if the Interactor was disabled. This was due
to the internal Interactor Rule becoming disabled and rules would
always be rejected on disabled components.

A recent change in Zinnia now means the Rule can still be queried
even if the component is on a deactivated GameObject. This fix simply
allows the Rule within the Interactor to still be queried when the
Interactor is disabled and therefore the CollisionStopped event still
correctly emits.